### PR TITLE
Refactor search and merge logic to respect ignore list for movie libraries

### DIFF
--- a/app.py
+++ b/app.py
@@ -31,81 +31,90 @@ logging.getLogger().addHandler(rotating_handler)
 # Emby server settings
 EMBY_BASE_URL = os.environ["EMBY_BASE_URL"]
 EMBY_API_KEY = os.environ["EMBY_API_KEY"]
+IGNORE_LIBRARY = os.environ["IGNORE_LIBRARY"]
 
 
 # set up requests session
-def requests_session():
-    session = requests.session()
-    session.headers.update(
-        {
-            "accept": "application/json",
-        }
-    )
-    return session
+session = requests.session()
+session.headers.update(
+    {
+        "accept": "application/json",
+    }
+)
+
+
+def check_ignore_list(item):
+    ignore_list = [id.strip() for id in IGNORE_LIBRARY.split(",") if IGNORE_LIBRARY]
+    return all(library not in item.get("Path") for library in ignore_list)
 
 
 # Merge HD and UHD Movies
-def merge_movies(item_id_1, item_id_2, movie_name_1, session):
+def merge_movies(item_id_1, item_id_2, movie_name_1):
     url = f"{EMBY_BASE_URL}/emby/Videos/MergeVersions?Ids={item_id_1},{item_id_2}&api_key={EMBY_API_KEY}"
-    response = session.post(
-        url,
-    )
-    if 200 <= response.status_code < 300:
+
+    try:
+        response = session.post(url)
+        response.raise_for_status()
         logging.info(f"Merge Successful for movie: {movie_name_1}")
         return f"Merge Successful for movie: {movie_name_1}"
-    else:
-        logging.error("Merge Unsuccessful")
-        return "Merge Unsuccessful"
+    except requests.exceptions.RequestException as e:
+        logging.error(f"An error occurred while merging movies: {e}")
+    return "An error occurred while merging movies"
 
 
-def search_movies(prov_id, session):
-    url = f"{EMBY_BASE_URL}/emby/Items?Recursive=true&AnyProviderIdEquals={prov_id}&api_key={EMBY_API_KEY}"
-    response = session.get(url)
-    movies_data = []
-    for item in response.json()["Items"]:
-        item_id = item["Id"]
-        item_name = item["Name"]
-        movies_data.append({"id": item_id, "name": item_name})
-    return movies_data
+def search_movies(prov_id):
+    url = f"{EMBY_BASE_URL}/emby/Items?Recursive=true&Fields=Path&AnyProviderIdEquals={prov_id}&api_key={EMBY_API_KEY}"
+    try:
+        response = session.get(url)
+        response.raise_for_status()
+        movies_data = []
+        for item in response.json()["Items"]:
+            if item.get("Type") == "Movie" and check_ignore_list(item):
+                item_id = item["Id"]
+                item_name = item["Name"]
+                movies_data.append({"id": item_id, "name": item_name})
+        return movies_data
+
+    except requests.exceptions.RequestException as e:
+        logging.error(f"An error occurred while searching for movies: {e}")
+    return "An error occurred while searching for movies"
 
 
 @app.route("/emby-webhook", methods=["POST"])
 def webhook_listener():
-    # start requests session
-    session = requests_session()
+
     try:
         data = json.loads(dict(request.form)["data"])
     except KeyError:
         data = json.loads(request.data)
 
-    # List of provider IDs to search with
     provider_id = "Tmdb"
-    # Search for movies using provider ID
+    movies = []
+
+    # Search for movies using provider ID until at least two movie IDs are found
     if "ProviderIds" in data["Item"] and provider_id in data["Item"]["ProviderIds"]:
         prov_key = provider_id.lower()  # Convert the provider key to lowercase
         prov_value = data["Item"]["ProviderIds"][provider_id]
-        movies = search_movies(f"{prov_key}.{prov_value}", session)
-        movie_name = movies[0]["name"] if movies else "unknown"
+        movies = search_movies(f"{prov_key}.{prov_value}")
+
+    movie_name = movies[0]["name"] if movies else "unknown"
 
     # merge movies
     if movies is not None and len(movies) == 2:
         movie_1, movie_2 = movies
-        merger = merge_movies(movie_1["id"], movie_2["id"], movie_1["name"], session)
-        session.close()
+        merger = merge_movies(movie_1["id"], movie_2["id"], movie_1["name"])
         return merger
 
     elif movies is not None and len(movies) > 2:
         logging.info(
-            f"No merge performed for {movie_name}, more than two movie IDs were found"
+            f"No merge performed for {movie_name}, more than two movies were found"
         )
-        session.close()
-        return "No merge performed more than two movie IDs were found"
+        return "No merge performed, more than two movies were found"
 
     else:
         logging.info(
             f"No merge performed for {movie_name}, not enough movie IDs were found"
         )
-        session.close()
         return "No merge performed, not enough movie IDs were found"
 
 


### PR DESCRIPTION
This commit enhances the movie search and merge functionalities by incorporating an ignore list. The ignore list is now checked against each movie's library path to filter out movies from specified libraries before any merge operation is attempted. This ensures that only movies from desired libraries are considered for merging, improving the tool's usability and flexibility.
